### PR TITLE
Fixing issues #75 and #77

### DIFF
--- a/src/bioservices/kegg.py
+++ b/src/bioservices/kegg.py
@@ -1269,11 +1269,11 @@ class KEGGParser(Logging):
                     value = value.replace("\n", " ")
                 # nothing to do here except strip
                 output[key] = value.strip()
-            # list : set iof lines. Could be split by ; character but we use the
+            # list : set of lines. Could be split by ; character but we use the
             # \n instead to be sure
             # COMMENT is sometimes on several lines
             elif key in ['NAME', 'REMARK', 'ACTIVITY', 'COMMENT', 'ORIGINAL_DB',
-                "SUBSTRATE", "PRODUCT"]:
+                "SUBSTRATE", "PRODUCT", "ENV_FACTOR", "PATHOGEN"]:
                 output[key] = [x.strip() for x in value.split("\n")]
             # list: long string splitted into items and therefore converted to a list
             elif key in ['ENZYME', 'REACTION',  'RPAIR', 'RELATEDPAIR',
@@ -1296,7 +1296,7 @@ class KEGGParser(Logging):
             # transform to dictionary
             elif key in ['DRUG', 'ORTHOLOGY', 'GENE', 'COMPOUND', 'RMODULE',
                     'DISEASE', 'PATHWAY_MAP',
-                    'STR_MAP', 'PATHWAY', 'MODULE', 'GENES']:
+                    'STR_MAP', 'OTHER_MAP', 'PATHWAY', 'MODULE', 'GENES']:
                 kp = {}
                 for line in value.split("\n"):
                     try: # empty orthology in rc:RC00004

--- a/src/bioservices/kegg.py
+++ b/src/bioservices/kegg.py
@@ -1240,7 +1240,9 @@ class KEGGParser(Logging):
             if k in ['CHROMOSOME', 'TAXONOMY']:
                 continue
             try:
-                output[k] = output[k].strip().replace(k,'',1) # remove the name that
+                output[k] = output[k].strip().replace(k, '', 1).strip()     # remove the name that
+                if not output[k]:
+                    output.pop(k)
             except: # skip the lists
                 pass
 


### PR DESCRIPTION
Hello Thomas,
I figured out what are `ENV_FACTOR`, `PATHOGEN`, and `OTHER_MAP` for, and added these keywords into the parser for KEGG. Since I use `bioservices.kegg` in my project, this information is important for me. This fixes the issue #75. Maybe you'll decide to include this code into the upstream.

One can check the correctness of this lines using the following code:
```python
from bioservices.kegg import KEGG
k = KEGG()

env_factors = [
            "ds:H01371",
            "ds:H00599",
            "ds:H01177",
            ]
pathogens = [
            "ds:H01619",
            "ds:H01027",
            "ds:H00313",
            "ds:H00286",
            "ds:H00408",
            "ds:H00344",
            "ds:H01509",
            "ds:H01240",
            "ds:H00437",
            ]
other_maps = [
            "dr:D07538",
            "dr:D08146",
            "dr:D00346",
            "dr:D03833",
            ]

for bad in env_factors + pathogens + other_maps:
    entry = k.get(bad)
    parsed_entry = k.parse(entry)
    print parsed_entry['ENTRY']
    if 'ENV_FACTOR' in entry:
        for e in parsed_entry['ENV_FACTOR']:
            print("\t>>> env_factors: {}".format(e))
    if 'PATHOGEN' in entry:
        for e in parsed_entry['PATHOGEN']:
            print("\t>>> pathogen: {}".format(e))
    if 'OTHER_MAP' in entry:
        for m, v in parsed_entry['OTHER_MAP'].items():
            print("\t>>> other_map: {}: {}".format(m, v))
```