### PR TITLE
Fix for TypeError on get_target_by_uniprotId when res is of type int

### DIFF
--- a/src/bioservices/chembl.py
+++ b/src/bioservices/chembl.py
@@ -77,11 +77,11 @@ class ChEMBL(REST):
     _target_approved_drugs_example = "CHEMBL1824"
     _target_refseq_example = 'NP_015325'
     _assays_example = "CHEMBL1217643"
-    _inspect_example = ('CHEMBL1','compound')
+    _inspect_example = ('CHEMBL1', 'compound')
 
     def __init__(self, verbose=False, cache=False):
         super(ChEMBL, self).__init__(url=ChEMBL._url,
-            name="ChEMBL", verbose=verbose, cache=cache)
+                                     name="ChEMBL", verbose=verbose, cache=cache)
 
     def _process(self, query, frmt, request):
         self.devtools.check_param_in_list(frmt, ["json", "xml"])
@@ -108,7 +108,7 @@ class ChEMBL(REST):
         """
         res = self.http_get("status", frmt="json")
         try:
-            #FIXME: wierd behaviour that is different on different systems...
+            # FIXME: wierd behaviour that is different on different systems...
             return res['status']
         except:
             return res
@@ -280,11 +280,11 @@ class ChEMBL(REST):
             >>> resjson = s.get_compounds_similar_to_SMILES(s._smiles_similar_example)
         """
         self.devtools.check_range(similarity, 70, 100)
-        res = self._process(query, frmt, "compounds/similarity/%s/"+str(similarity))
+        res = self._process(query, frmt, "compounds/similarity/%s/" + str(similarity))
         return self._postprocess(res, 'compounds')
 
     def get_image_of_compounds_by_chemblId(self, query, dimensions=500,
-            save=True, view=True, engine="rdkit"):
+                                           save=True, view=True, engine="rdkit"):
         """Get the image of a given compound in PNG png format.
 
         :param str query: a valid compound ChEMBLId or a list/tuple of valid compound ChEMBLIds.
@@ -309,16 +309,16 @@ class ChEMBL(REST):
         .. todo:: ignorecoords option
         """
         # NOTE: not async requests here.
-        self.devtools.check_range(dimensions, 1,500)
+        self.devtools.check_range(dimensions, 1, 500)
         self.devtools.check_param_in_list(engine, ['rdkit'])
         queries = self.devtools.to_list(query)
 
-        res = {'filenames':[], 'images':[], 'chemblids':[]}
+        res = {'filenames': [], 'images': [], 'chemblids': []}
         for query in queries:
             req = "compounds/%s/image" % query
-            #url=self.url+'compounds/%s/image' % query
+            # url=self.url+'compounds/%s/image' % query
             if dimensions is not None:
-                req += '?engine=%s&dimensions=%s'%(engine, dimensions)
+                req += '?engine=%s&dimensions=%s' % (engine, dimensions)
             target_data = self.http_get(req, frmt=None)
 
             file_out = os.getcwd()
@@ -407,7 +407,7 @@ class ChEMBL(REST):
             >>> resjson = s.get_target_by_uniprotId(s._target_uniprotId_example)
         """
         res = self._process(query, frmt, "targets/uniprot/%s")
-        if frmt == 'json':
+        if frmt == 'json' and not isinstance(res, int):
             res = res['target']
         return res
 
@@ -565,38 +565,37 @@ class ChEMBL(REST):
             >>> s.inspect(s._assays_example,'assay')
 
         """
-        url = "https://www.ebi.ac.uk/chembldb/%s/inspect/%s"%(item_type, query)
+        url = "https://www.ebi.ac.uk/chembldb/%s/inspect/%s" % (item_type, query)
         webbrowser.open(url)
 
     def version(self):
         """Return version of the API on the server"""
         res = self.http_get("status", frmt="json")
         try:
-            #FIXME: wierd behaviour that is different on different systems...
+            # FIXME: wierd behaviour that is different on different systems...
             return res['version']
         except:
             return res
 
 
 class BenchmarkChembl(ChEMBL):
-
     def __init__(self):
         super(BenchmarkChembl, self).__init__(cache=True)
 
     def benchmark(self, N=1000):
-        #self.name = "compounds"
+        # self.name = "compounds"
         import time
         t1 = time.time()
-        res = self.get_compounds_by_chemblId(['CHEMBL%s' % i for i in range(1,N)])
+        res = self.get_compounds_by_chemblId(['CHEMBL%s' % i for i in range(1, N)])
         t2 = time.time()
-        res1 = t2-t1
-        print(t2-t1)
+        res1 = t2 - t1
+        print(t2 - t1)
 
         t1 = time.time()
-        res = [self.get_compounds_by_chemblId('CHEMBL%s' % i) for i in range(1,N)]
+        res = [self.get_compounds_by_chemblId('CHEMBL%s' % i) for i in range(1, N)]
         t2 = time.time()
-        res2   = t2-t1
-        print(t2-t1)
+        res2 = t2 - t1
+        print(t2 - t1)
 
         return res, res1, res2
 
@@ -607,25 +606,23 @@ class BenchmarkChembl(ChEMBL):
         import time
 
         t1 = time.time()
-        res = compounds.get(['CHEMBL%s' % x for x in range(1,N)])
+        res = compounds.get(['CHEMBL%s' % x for x in range(1, N)])
         t2 = time.time()
 
-        res1 = t2-t1
-        print(t2-t1)
+        res1 = t2 - t1
+        print(t2 - t1)
 
         t1 = time.time()
-        res = [compounds.get('CHEMBL%s' % x) for x in range(1,N)]
+        res = [compounds.get('CHEMBL%s' % x) for x in range(1, N)]
         t2 = time.time()
 
-        res2 = t2-t1
-        print(t2-t1)
+        res2 = t2 - t1
+        print(t2 - t1)
         return res, res1, res2
 
-
-    def compare_benchmark(self,n=10, N=1000):
-
-        df = {'bs_sync':[], 'bs_normal':[], 'ch_sync':[], 'ch_normal':[]}
-        for i in range(0,n):
+    def compare_benchmark(self, n=10, N=1000):
+        df = {'bs_sync': [], 'bs_normal': [], 'ch_sync': [], 'ch_normal': []}
+        for i in range(0, n):
             print(i)
             res, res1, res2 = self.benchmark(N)
             df['bs_sync'].append(res1)
@@ -638,7 +635,7 @@ class BenchmarkChembl(ChEMBL):
         df = pd.DataFrame(df)
         import pylab
         pylab.clf()
-        df  = df[['bs_normal','ch_normal','bs_sync','ch_sync']]
+        df = df[['bs_normal', 'ch_normal', 'bs_sync', 'ch_sync']]
         pylab.axvline(2.5)
         df.boxplot()
         return df

--- a/src/bioservices/quickgo.py
+++ b/src/bioservices/quickgo.py
@@ -76,9 +76,9 @@ class QuickGO(REST):
     """
     _goid_example = "GO:0003824"
     _valid_col = ['proteinDB', 'proteinID', 'proteinSymbol', 'qualifier',
-            'goID', 'goName', 'aspect', 'evidence', 'ref', 'with', 'proteinTaxon',
-            'date', 'from', 'splice', 'proteinName', 'proteinSynonym', 'proteinType',
-            'proteinTaxonName', 'originalTermID', 'originalGOName']
+                  'goID', 'goName', 'aspect', 'evidence', 'ref', 'with', 'proteinTaxon',
+                  'date', 'from', 'splice', 'proteinName', 'proteinSynonym', 'proteinType',
+                  'proteinTaxonName', 'originalTermID', 'originalGOName']
 
     def __init__(self, verbose=False, cache=False):
         """.. rubric:: Constructor
@@ -86,8 +86,8 @@ class QuickGO(REST):
         :param bool verbose: print informative messages.
 
         """
-        super(QuickGO, self).__init__(url="http://www.ebi.ac.uk/QuickGO",
-            name="quickGO", verbose=verbose, cache=cache)
+        super(QuickGO, self).__init__(url="http://www.ebi.ac.uk/QuickGO-Old",
+                                      name="quickGO", verbose=verbose, cache=cache)
 
     def Term(self, goid, frmt="oboxml"):
         """Obtain Term information
@@ -110,18 +110,18 @@ class QuickGO(REST):
 
         """
         self.devtools.check_param_in_list(frmt, ["mini", "obo", "oboxml"])
-        if goid.startswith("GO:")is False:
+        if goid.startswith("GO:") is False:
             raise ValueError("GO id must start with 'GO:'")
 
-        params = {'id':goid, 'format': frmt}
+        params = {'id': goid, 'format': frmt}
         res = self.http_get("GTerm", frmt="xml", params=params)
 
         return res
 
     def Annotation(self, goid=None, protein=None, frmt="gaf", limit=10000,
-            gz=False, col=None, db=None, aspect=None, relType=None, termUse=None,
-            evidence=None, source=None, ref=None,  tax=None, qualifier=None, q=None, 
-            _with=None):
+                   gz=False, col=None, db=None, aspect=None, relType=None, termUse=None,
+                   evidence=None, source=None, ref=None, tax=None, qualifier=None, q=None,
+                   _with=None):
         """Calling the Annotation service
 
         Mutual exclusive parameters are goid, protein
@@ -207,7 +207,7 @@ class QuickGO(REST):
         elif tax is not None:
             url += "tax=" + tax
 
-        #need to check that there are mutualy exclusive
+        # need to check that there are mutualy exclusive
         if goid is None and protein is None and tax is None:
             raise ValueError("you must provide at least one of the following parameter: goid, protein")
 
@@ -228,9 +228,9 @@ class QuickGO(REST):
             raise NotImplementedError
 
         if evidence:
-            if isinstance(evidence,list):
+            if isinstance(evidence, list):
                 evidence = ",".join([x.strip() for x in evidence])
-            elif isinstance(evidence,str):
+            elif isinstance(evidence, str):
                 pass
             else:
                 raise ValueError("""
@@ -261,7 +261,7 @@ or a string (e.g., 'PUBMED:*') """)
             params['ref'] = ref
 
         if qualifier:
-            #NOT, colocalizes_with, contributes_to
+            # NOT, colocalizes_with, contributes_to
             if isinstance(qualifier, list):
                 qualifier = ",".join([x.strip() for x in qualifier])
             elif isinstance(qualifier, str):
@@ -285,7 +285,8 @@ or a string (e.g., 'PUBMED:*') """)
         if frmt not in ["tsv", "dict"]:
             # col is provided but format is not appropriate
             if col is not None:
-                raise ValueError("You provided the 'col' parameter but the format is not correct. You should use the frmt='tsv' or frmt='dict' ")
+                raise ValueError(
+                    "You provided the 'col' parameter but the format is not correct. You should use the frmt='tsv' or frmt='dict' ")
 
         # gz parameter. do not expect values so need to be added afterwards.
         if gz is True:
@@ -306,7 +307,7 @@ or a string (e.g., 'PUBMED:*') """)
 
         """
         kargs["frmt"] = "tsv"
-        cols = ",".join (self._valid_col)
+        cols = ",".join(self._valid_col)
         kargs['col'] = cols
 
         data = self.Annotation(goid=goid, **kargs)
@@ -323,7 +324,8 @@ or a string (e.g., 'PUBMED:*') """)
             import pandas as pd
             return pd.DataFrame(res)
         except:
-            self.logging.warning("Cannot return a DataFrame. Returns the list. If you want the dataframe, install pandas library")
+            self.logging.warning(
+                "Cannot return a DataFrame. Returns the list. If you want the dataframe, install pandas library")
             return res
 
     def Annotation_from_protein(self, protein, **kargs):
@@ -337,7 +339,7 @@ or a string (e.g., 'PUBMED:*') """)
 
         """
         kargs["frmt"] = "tsv"
-        cols = ",".join (self._valid_col)
+        cols = ",".join(self._valid_col)
         kargs['col'] = cols
 
         data = self.Annotation(protein=protein, **kargs)
@@ -356,7 +358,6 @@ or a string (e.g., 'PUBMED:*') """)
         except:
             self.logging.warning("Cannot return a DAtaFrame. Returns the list")
             return res
-
 
 
 class GeneOntology():
@@ -379,10 +380,9 @@ class GeneOntology():
 
 
     """
+
     def __init__(self):
         self._quickgo = QuickGO(verbose=False)
 
     def getGOTerm(self, goid):
         return self._quickgo.Term(goid, frmt="obo")
-
-


### PR DESCRIPTION
- Updated QuickGo url to http://www.ebi.ac.uk/QuickGO-Old/
- Checked type of  `res` before res['target'] in `get_target_by_uniprotId`.  
   - Got `TypeError: 'int' object has no attribute '__getitem__'` when calling `get_target_by_uniprotId` with `Q79G13`
