### PR TITLE
Fix for sequence being considered 'float' in get_df

### DIFF
--- a/src/bioservices/uniprot.py
+++ b/src/bioservices/uniprot.py
@@ -651,6 +651,9 @@ class UniProt(REST):
                 self.logging.warning("column could not be parsed. %s" % col)
         # Sequences are splitted into chunks of 10 characters. let us rmeove
         # the spaces:
-        output.Sequence = output['Sequence'].apply(lambda x: x.replace(" ", ""))
-
+        try:
+            output.Sequence = output['Sequence'].apply(lambda x: x.replace(" ", ""))
+        except:
+            output.Sequence = ""
+            
         return output

--- a/src/bioservices/uniprot.py
+++ b/src/bioservices/uniprot.py
@@ -651,7 +651,7 @@ class UniProt(REST):
                 self.logging.warning("column could not be parsed. %s" % col)
         # Sequences are splitted into chunks of 10 characters. let us rmeove
         # the spaces:
-        output['Sequence'].fillna("")
+        output['Sequence'].fillna("", inplace=True)
         output.Sequence = output['Sequence'].apply(lambda x: x.replace(" ", ""))
         
         return output

--- a/src/bioservices/uniprot.py
+++ b/src/bioservices/uniprot.py
@@ -651,9 +651,7 @@ class UniProt(REST):
                 self.logging.warning("column could not be parsed. %s" % col)
         # Sequences are splitted into chunks of 10 characters. let us rmeove
         # the spaces:
-        try:
-            output.Sequence = output['Sequence'].apply(lambda x: x.replace(" ", ""))
-        except:
-            output.Sequence = ""
-            
+        output['Sequence'].fillna("")
+        output.Sequence = output['Sequence'].apply(lambda x: x.replace(" ", ""))
+        
         return output


### PR DESCRIPTION
Following error comes up in some cases:
output.Sequence = output['Sequence'].apply(lambda x: x.replace(" ", ""))
E   AttributeError: 'float' object has no attribute 'replace'
Pull request fixes this error