### PR TITLE
remove last / in eutils URL

### DIFF
--- a/src/bioservices/eutils.py
+++ b/src/bioservices/eutils.py
@@ -103,7 +103,7 @@ class EUtils(REST):
     """
     def __init__(self, verbose=False, email="unknown", cache=False,
                 xmlparser="EUtilsParser"):
-        url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+        url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
         super(EUtils, self).__init__(name="EUtils", verbose=verbose, url=url,
             cache=cache)
 


### PR DESCRIPTION
bioservices builds the URL by joining baseurl and path (e.g. einfo) with a '/' character (see https://github.com/cokelaer/bioservices/blob/master/src/bioservices/services.py#L745)

current URL results in a query to `https://eutils.ncbi.nlm.nih.gov/entrez/eutils//einfo.fcgi?retmode=json`, response is a 400 code
new URL will be `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?retmode=json`, response is 200 and it works!
Because the former used to work before, I guess there was a recent change in eutils and it does not behave the way it used to.

@cokelaer can you check and merge? correction works locally for my use case at least.
many thanks to @racheltorchet for spotting this anyway.