### PR TITLE
Update UniProt URL to use https instead of http

### DIFF
--- a/src/bioservices/uniprot.py
+++ b/src/bioservices/uniprot.py
@@ -177,7 +177,7 @@ class UniProt(REST):
 
     """
     _mapping = mapping.copy()
-    _url = "http://www.uniprot.org"
+    _url = "https://www.uniprot.org"
     # _valid_columns = ['citation', 'clusters', 'comments', 'database',
     #                   'domains', 'domain', 'ec', 'id', 'entry name', 'existence',
     #                   'families', 'feature', 'features', 'genes', 'go', 'go-id', 'interpro',


### PR DESCRIPTION
As of June 20, 2018, UniProt switched to encrypted web traffic and services such as the ID mapping won't work unless pointed to the https:// address. See: https://www.uniprot.org/news/2018/06/20/release