### PR TITLE
Improve input/return/exception handling of KEGG parse methods

### DIFF
--- a/src/bioservices/kegg.py
+++ b/src/bioservices/kegg.py
@@ -1088,12 +1088,14 @@ class KEGG(REST):
             d = k.parse(res)
 
         """
+        parse = dict()
+
         try:
-            res = self.keggParser.parse(entry)
-            return res
+            parse = self.keggParser.parse(entry)
         except:
             self.logging.warning('Could not parse the entry correctly.')
-            return entry
+
+        return parse
 
 
 class KEGGParser(object):
@@ -1186,25 +1188,32 @@ class KEGGParser(object):
 
             >>> d = s.parse(res)
         """
-        entry = res.split("\n")[0].split()[0]
-        if entry == "ENTRY":
+        parser = dict()
+        dbentry = "?"
+
+        # get() should return a large amount of text data
+        if not isinstance(res, str):
+            raise ValueError("Unexpected input, unable to parse data of type %s" % type(res))
+
+        if res[:5] == "ENTRY":
             dbentry = res.split("\n")[0].split(None, 2)[2]
         else:
-            dbentry='?'
-            raise ValueError
+            raise ValueError("Unable to parse data, it does not comform to expected KEGG format")
 
         try:
             parser = self._parse(res)
         except Exception as err:
             self.logging.warning("Could not parse the entry %s correctly" % dbentry)
             self.logging.warning(err)
-            parser = res
+
         return parser
 
     def _parse(self, res):
+        # If the result is a response code and not data,
+        # simply return an empty dict as there is nothing to parse
+        if isinstance(res, int):
+            return dict()
 
-        if res == 404:
-            return
         keys = [x.split(" ")[0] for x in res.split("\n") if len(x) and x[0]!=" "
                 and x!="///"]
         # let us go line by to not forget anything and know which entries are

--- a/src/bioservices/kegg.py
+++ b/src/bioservices/kegg.py
@@ -1192,13 +1192,13 @@ class KEGGParser(object):
         dbentry = "?"
 
         # get() should return a large amount of text data
-        if not isinstance(res, str):
+        if not res or not isinstance(res, str):
             raise ValueError("Unexpected input, unable to parse data of type %s" % type(res))
 
         if res[:5] == "ENTRY":
             dbentry = res.split("\n")[0].split(None, 2)[2]
         else:
-            raise ValueError("Unable to parse data, it does not comform to expected KEGG format")
+            raise ValueError("Unable to parse data, it does not comform to the expected KEGG format")
 
         try:
             parser = self._parse(res)
@@ -1209,11 +1209,6 @@ class KEGGParser(object):
         return parser
 
     def _parse(self, res):
-        # If the result is a response code and not data,
-        # simply return an empty dict as there is nothing to parse
-        if isinstance(res, int):
-            return dict()
-
         keys = [x.split(" ")[0] for x in res.split("\n") if len(x) and x[0]!=" "
                 and x!="///"]
         # let us go line by to not forget anything and know which entries are

--- a/test/test_kegg.py
+++ b/test/test_kegg.py
@@ -2,12 +2,17 @@ from bioservices import KEGG, KEGGParser
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture(scope = "module")
 def kegg():
     k = KEGG()
     k.organismIds
     k.organism = "hsa"
     return k
+
+
+@pytest.fixture(params = [None, "", 0, 400, {}])
+def parse_input(request):
+    yield request.param
 
 
 # This is a simple test class that do not test everything on purpose.
@@ -139,6 +144,13 @@ def test_get(kegg):
     except:
         assert True
 
+
+def test_parse(kegg, parse_input):
+    # Check that parse can handle return values that get()
+    # might reasonably produce like Service.response_codes
+    assert isinstance(kegg.parse(parse_input), dict)
+
+
 def test_conv(kegg):
     kegg.conv("ncbi-gi","hsa:10458+ece:Z5100")
 
@@ -217,25 +229,9 @@ def test_KEGGParser(kegg):
     assert d['SEQUENCE'][0]['TYPE'] == "NRP"
 
 
+def test_KEGGParser_parse_invalid(parse_input):
+    kp = KEGGParser()
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    # Check that an exception is raised for invalid input
+    with pytest.raises(ValueError):
+        kp.parse(parse_input)


### PR DESCRIPTION
Hi, I stumbled across your project via [one of the issues](https://github.com/cokelaer/bioservices/issues/165) raised on your repo. After digging around a bit in the kegg module I found that `KEGG.get` usually returns a string containing the expected data, but may also return a code from `Services.Service.response_codes`. `KEGG.parse` is not able to handle this, or other 'problem' inputs

I have changed `KEGG.parse`, `KEGGParser.parse` and `KEGGParser._parse` so they are more resilient to unexpected input, and are consistent in their return types.

One other small change: I changed the scope of the `kegg` test fixture to `module` so it can be reused across the tests. This massively reduces the time taken to run them.