### PR TITLE
Correct uniprot API column reference

### DIFF
--- a/src/bioservices/uniprot.py
+++ b/src/bioservices/uniprot.py
@@ -232,7 +232,7 @@ class UniProt(REST):
         # Structure
         '3d', 'feature(BETA STRAND)', 'feature(HELIX)', 'feature(TURN)',
         # Subcellular location
-        'feature(SUBCELLULAR LOCATION)', 'feature(INTRAMEMBRANE)',
+        'comment(SUBCELLULAR LOCATION)', 'feature(INTRAMEMBRANE)',
         'feature(TOPOLOGICAL DOMAIN)',
         'feature(TRANSMEMBRANE)',
         # Miscellaneous


### PR DESCRIPTION
Closes https://github.com/cokelaer/bioservices/issues/163 by reverting the change introduced in https://github.com/cokelaer/bioservices/commit/17445431781b9be5730992e3fe0944f3d6f308df