### PR TITLE
Fix issue with compress in uniprot search.

### DIFF
--- a/src/bioservices/uniprot.py
+++ b/src/bioservices/uniprot.py
@@ -690,7 +690,7 @@ class UniProt:
             params["includeIsoform"] = "yes"
 
         if compress is True:
-            params["compress"] = "yes"
+            params["compressed"] = "true"
 
         if sort:
             self.services.devtools.check_param_in_list(sort, ["score"])


### PR DESCRIPTION
Hi,

I was trying to download compressed fasta from UniProt using bioservices `search`. But this function did not return compressed result, instead it returns an uncompressed fasta string.

An example:

```python
import bioservices
uniprot_bioservices = bioservices.UniProt(verbose=False)
data = uniprot_bioservices.search('P57263', database='uniprot', frmt='fasta', compress=True)
```
Returns:
```
0it [00:00, ?it/s]
>sp|P57263|NUOM_BUCAI NADH-quinone oxidoreductase subunit M OS=Buchnera aphidicola subsp. Acyrthosiphon pisum (strain APS) OX=107806 GN=nuoM PE=3 SV=1
MLLSLLIIIPFLSSFFSFFSPRLHNNFPRWIALSGIIATLLVVIQIFFQENYHIFQIRHY
PNWNCQLIVPWISRFGIEFNIALDGLSIIMLIFSSFLSIIAIICSWNEIKKNEGFFYFNF
MLVFTGIIGVFISCDLFLFFCFWEIMLIPMYFLIALWSDKTEKKKNFLAANKFFLYSQTS
GLILLSSILLLVFSHYYSTNILTFNYNLLINKPINIYVEYIVMIGFFLSFAIKMPIVPFH
GWLPDIHSRSLSCGSVEIIGVLLKTAPYALLRYNLVLFPDSTKSFSLIAVFWGIISIFYG
AWIAFSQTNIKRLIAYSSVSHMGLILIGIYSNNERALQGVVIQMLSNSLTVAALCILSGQ
IYKRFKTQDMSKMGGLWSCIYWIPGFSLFFSLANLGVPGTGNFIGEFLILSGVFEVFPLV
SILATIGIVFSSIYSLNVIQKIFYGPCKQNIKVFFINKQEVWTIIALVFTLVFLGLNPQK
IIDVSYNSIHNIQKEFNNSILKIRS

```

It is caused by wrong parameter and value in the search function. This Pull request should fix this issue.

Do you think that the variable `compress` of search function should be renamed to match `compressed`?
I think not as it breaks compatibility with script using this function but as the other parameters seem to be matching the ones of Uniprot, I prefer asking this.