### PR TITLE
Updated logging instance

### DIFF
--- a/src/bioservices/biodbnet.py
+++ b/src/bioservices/biodbnet.py
@@ -146,7 +146,7 @@ class BioDBNet:
             df.index.name = input_db
             return df
         except Exception as err:
-            self.logging.error(err)
+            self.services.logging.error(err)
             return request
 
     def dbFind(self, output_db, input_values, taxon="9606"):
@@ -254,7 +254,7 @@ class BioDBNet:
             df.index.name = input_db
             return df
         except Exception as err:
-            self.logging.error(err)
+            self.services.logging(err)
             return request
         inputValues = self._interpret_input_db(inputValues)
 


### PR DESCRIPTION
This pull request uses Bioservices' `self.services.logging` as the logger, instead of `self.logging`, which doesn't exist.