### PR TITLE
Update PDBe to v2 API

### DIFF
--- a/src/bioservices/pdbe.py
+++ b/src/bioservices/pdbe.py
@@ -16,7 +16,7 @@
 #  documentation: http://bioservices.readthedocs.io
 #
 ##############################################################################
-"""Interface to the PDBe web Service.
+"""Interface to the PDBe web Service (v2 API).
 
 .. topic:: What is PDBe ?
 
@@ -35,6 +35,8 @@
 
 """
 
+import json as _json
+
 from bioservices.services import REST
 
 __all__ = ["PDBe"]
@@ -51,13 +53,15 @@ class PDBe:
 
     """
 
+    _entry_prefix = "pdb/entry"
+
     def __init__(self, verbose=False, cache=False):
         """.. rubric:: Constructor
 
         :param bool verbose: prints informative messages (default is off)
 
         """
-        url = "https://www.ebi.ac.uk/pdbe/api/pdb/entry"
+        url = "https://www.ebi.ac.uk/pdbe/api/v2"
         self.services = REST(name="PDBe", url=url, verbose=verbose, cache=cache, url_defined_later=True)
 
     def _check_id(self, pdbid):
@@ -75,9 +79,37 @@ class PDBe:
         return pdbid
 
     def _return(self, res):
-        if res == 404:
+        if res in (404, 410):
             return {}
         return res
+
+    def _post_json(self, endpoint, query):
+        """Send a POST request with JSON content type to the v2 API.
+
+        The v2 API expects POST bodies as JSON-encoded strings containing
+        comma-separated PDB IDs.
+        """
+        headers = self.services.get_headers("json")
+        return self.services.http_post(
+            endpoint,
+            data=_json.dumps(query),
+            frmt="json",
+            headers=headers,
+        )
+
+    def _get_or_post(self, endpoint, query):
+        """Handle single PDB ID via GET or multiple PDB IDs via POST.
+
+        :param endpoint: the API endpoint name (e.g. 'summary', 'molecules')
+        :param query: a PDB id, a comma-separated string of PDB ids, or a list of PDB ids
+        :returns: the API response
+        """
+        query = self._check_id(query)
+        if "," not in query:
+            res = self.services.http_get("{}/{}/{}".format(self._entry_prefix, endpoint, query))
+        else:
+            res = self._post_json("{}/{}".format(self._entry_prefix, endpoint), query)
+        return self._return(res)
 
     def get_summary(self, query):
         """Returns summary of a PDB entry
@@ -95,15 +127,10 @@ class PDBe:
             p.get_summary(['1cbs', '2kv8'])
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("summary/{}".format(query))
-        else:
-            res = self.services.http_post("summary", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("summary", query)
 
     def get_molecules(self, query):
-        """Return details of molecules  (or entities in mmcif-speak) modelled in the entry
+        """Return details of molecules (or entities in mmcif-speak) modelled in the entry
 
         This can be entity id, description, type, polymer-type (if applicable), number
         of copies in the entry, sample preparation method, source organism(s)
@@ -114,37 +141,59 @@ class PDBe:
         ::
 
             p.get_molecules('1cbs')
+            p.get_molecules('1cbs,2kv8')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("molecules/{}".format(query))
-        else:
-            res = self.services.http_post("molecules", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("molecules", query)
+
+    def get_entities(self, query):
+        """Return details of entities modelled in the entry
+
+        This is an alias for :meth:`get_molecules` using the ``entities`` endpoint.
+
+        :param query: a 4-character PDB id code
+
+        ::
+
+            p.get_entities('1cbs')
+            p.get_entities('1cbs,2kv8')
+
+        """
+        return self._get_or_post("entities", query)
+
+    def get_publications(self, query):
+        """Return publications associated with the entry
+
+        Provides details of publications associated with an entry, such as title
+        of the article, journal name, year of publication, volume, pages, doi,
+        pubmed_id, etc. Primary citation is listed first.
+
+        :param query: a 4-character PDB id code
+
+        ::
+
+            p.get_publications('1cbs')
+            p.get_publications('1cbs,2kv8')
+
+        """
+        return self._get_or_post("publications", query)
 
     def get_related_publications(self, query):
-        """Return publications obtained from both EuroPMC and UniProt. T
-
+        """Return publications obtained from both EuroPMC and UniProt.
 
         These are articles which cite the primary citation of the entry, or
         open-access articles which mention the entry id without explicitly citing the
         primary citation of an entry.
-
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_related_publications('1cbs')
+            p.get_related_publications('1cbs,2kv8')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("related_publications/{}".format(query))
-        else:
-            res = self.services.http_post("related_publications/", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("related_publications", query)
 
     def get_experiment(self, query):
         """Provides details of experiment(s) carried out in determining the structure of the entry.
@@ -162,92 +211,53 @@ class PDBe:
         ::
 
             p.get_experiment('1cbs')
+            p.get_experiment('1cbs,2kv8')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("experiment/{}".format(query))
-        else:
-            res = self.services.http_post("experiment/{}", data=query, frmt="json")
-        return self._return(res)
-
-    def get_nmr_resources(self, query):
-        """This call provides URLs of available additional resources for NMR
-        entries. E.g., mapping between structure (PDB) and chemical shift (BMRB)
-        entries.
-        :param query: a 4-character PDB id code
-
-        ::
-
-            p.get_nmr_resources('1cbs')
-
-        """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("nmr_resources/{}".format(query))
-        else:
-            res = self.services.http_post("nmr_resources/", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("experiment", query)
 
     def get_ligand_monomers(self, query):
-        """Provides a a list of modelled instances of ligands,
+        """Provides a list of modelled instances of ligands,
 
-        ligands i.e. 'bound' molecules that are not waters.
+        i.e. 'bound' molecules that are not waters.
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_ligand_monomers('1cbs')
-
+            p.get_ligand_monomers('1cbs,2kv8')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("ligand_monomers/{}".format(query))
-        else:
-            res = self.services.http_post("ligand_monomers", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("ligand_monomers", query)
 
     def get_modified_residues(self, query):
         """Provides a list of modelled instances of modified amino acids or
         nucleotides in protein, DNA or RNA chains.
-
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_modified_residues('4v5j')
-
+            p.get_modified_residues('4v5j,1cbs')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("modified_AA_or_NA/{}".format(query))
-        else:
-            res = self.services.http_post("modified_AA_or_NA", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("modified_AA_or_NA", query)
 
     def get_mutated_residues(self, query):
         """Provides a list of modelled instances of mutated amino acids or
         nucleotides in protein, DNA or RNA chains.
-
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_mutated_residues('1bgj')
-
+            p.get_mutated_residues('1bgj,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("mutated_AA_or_NA/{}".format(query))
-        else:
-            res = self.services.http_get("mutated_AA_or_NA", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("mutated_AA_or_NA", query)
 
     def get_release_status(self, query):
         """Provides status of a PDB entry (released, obsoleted, on-hold etc)
@@ -259,50 +269,41 @@ class PDBe:
         ::
 
             p.get_release_status('1cbs')
-
+            p.get_release_status('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("status/{}".format(query))
-        else:
-            res = self.services.http_get("status/{}", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("status", query)
 
     def get_observed_ranges(self, query):
         """Provides observed ranges, i.e., segments of structural coverage of
-         polymeric molecues that are modelled fully or partly
+        polymeric molecules that are modelled fully or partly.
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_observed_ranges('1cbs')
-
+            p.get_observed_ranges('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("polymer_coverage/{}".format(query))
-        else:
-            res = self.services.http_post("polymer_coverage", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("polymer_coverage", query)
 
     def get_observed_ranges_in_pdb_chain(self, query, chain_id):
         """Provides observed ranges, i.e., segments of structural coverage of
-         polymeric molecules in a particular chain
+        polymeric molecules in a particular chain.
 
         :param query: a 4-character PDB id code
-        :param query: a PDB chain ID
+        :param chain_id: a PDB chain ID
 
         ::
 
-            p.get_observed_ranges_in_pdb_chain('1cbs', "A")
-
+            p.get_observed_ranges_in_pdb_chain('1cbs', 'A')
 
         """
-        assert len(query) == 4, "a 4-character PDB id code is required"
-        res = self.services.http_get("polymer_coverage/{}/chain/{}".format(query, chain_id))
+        query = self._check_id(query)
+        res = self.services.http_get(
+            "{}/polymer_coverage/{}/chain/{}".format(self._entry_prefix, query, chain_id)
+        )
         return self._return(res)
 
     def get_secondary_structure(self, query):
@@ -311,29 +312,21 @@ class PDBe:
         (alpha helices and beta strands) found in protein chains of the entry.
         For strands, sheet id can be used to identify a beta sheet.
 
-
-
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_secondary_structure('1cbs')
-
+            p.get_secondary_structure('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("secondary_structure/{}".format(query))
-        else:
-            res = self.services.http_post("secondary_structure/", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("secondary_structure", query)
 
     def get_residue_listing(self, query):
-        """Provides lists all residues (modelled or otherwise) in the entry.
+        """Lists all residues (modelled or otherwise) in the entry.
 
         Except waters, along with details of the fraction of expected atoms modelled for
         the residue and any alternate conformers.
-
 
         :param query: a 4-character PDB id code
 
@@ -341,53 +334,51 @@ class PDBe:
 
             p.get_residue_listing('1cbs')
 
-
         """
-        assert len(query) == 4, "a 4-character PDB id code is required"
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("residue_listing/{}".format(query))
+        query = self._check_id(query)
+        res = self.services.http_get(
+            "{}/residue_listing/{}".format(self._entry_prefix, query)
+        )
         return self._return(res)
 
     def get_residue_listing_in_pdb_chain(self, query, chain_id):
-        """Provides all residues (modelled or otherwise) in the entry
+        """Lists all residues (modelled or otherwise) in a particular chain.
 
         Except waters, along with details of the fraction of expected atoms
         modelled for the residue and any alternate conformers.
 
         :param query: a 4-character PDB id code
-        :param query: a PDB chain ID
+        :param chain_id: a PDB chain ID
 
         ::
 
-            p.get_residue_listing_in_pdb_chain('1cbs')
-
+            p.get_residue_listing_in_pdb_chain('1cbs', 'A')
 
         """
-        assert len(query) == 4, "a 4-character PDB id code is required"
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("residue_listing/{}".format(query, chain_id))
+        query = self._check_id(query)
+        res = self.services.http_get(
+            "{}/residue_listing/{}/chain/{}".format(self._entry_prefix, query, chain_id)
+        )
         return self._return(res)
 
-    def get_binding_sites(self, query):
-        """Pprovides details on binding sites in the entry
+    def get_binding_sites(self, query, entity_id):
+        """Provides details on binding sites for a specific entity in the entry.
 
         STRUCT_SITE records in PDB files (or mmcif equivalent thereof), such as ligand,
         residues in the site, description of the site, etc.
 
-
         :param query: a 4-character PDB id code
+        :param entity_id: an entity ID (integer or string)
 
         ::
 
-            p.get_binding_sites('1cbs')
-
+            p.get_binding_sites('1cbs', 1)
 
         """
         query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("binding_sites/{}".format(query))
-        else:
-            res = self.services.http_post("binding_sites", data=query, frmt="json")
+        res = self.services.http_get(
+            "{}/binding_sites/{}/{}".format(self._entry_prefix, query, entity_id)
+        )
         return self._return(res)
 
     def get_files(self, query):
@@ -402,39 +393,29 @@ class PDBe:
         ::
 
             p.get_files('1cbs')
-
+            p.get_files('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("files/{}".format(query))
-        else:
-            res = self.services.http_post("files", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("files", query)
 
     def get_observed_residues_ratio(self, query):
-        """Provides the ratio of observed residues for each chain in each molecule
+        """Provides the ratio of observed residues for each chain in each molecule.
 
         The list of chains within an entity is sorted by observed_ratio (descending order),
-         partial_ratio (ascending order), and number_residues (descending order).
+        partial_ratio (ascending order), and number_residues (descending order).
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_observed_residues_ratio('1cbs')
-
+            p.get_observed_residues_ratio('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("observed_residues_ratio/{}".format(query))
-        else:
-            res = self.services.http_post("observed_residues_ratio", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("observed_residues_ratio", query)
 
     def get_assembly(self, query):
-        """Provides information for each assembly of a given PDB ID. T
+        """Provides information for each assembly of a given PDB ID.
 
         This information is broken down at the entity level for each assembly. The
         information given includes the molecule name, type and class, the chains where
@@ -445,36 +426,26 @@ class PDBe:
         ::
 
             p.get_assembly('1cbs')
-
+            p.get_assembly('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("assembly/{}".format(query))
-        else:
-            res = self.services.http_post("assembly", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("assembly", query)
 
     def get_electron_density_statistics(self, query):
-        """This call details the statistics for electron density.
+        """Provides statistics for electron density.
 
         :param query: a 4-character PDB id code
 
         ::
 
             p.get_electron_density_statistics('1cbs')
-
+            p.get_electron_density_statistics('1cbs,4v5j')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("electron_density_statistics/{}".format(query))
-        else:
-            res = self.services.http_post("electron_density_statistics", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("electron_density_statistics", query)
 
     def get_functional_annotation(self, query):
-        """Provides functional annotation of all ligands, i.e. 'bound'
+        """Provides functional annotation of all ligands, i.e. 'bound' molecules.
 
         :param query: a 4-character PDB id code
 
@@ -482,17 +453,15 @@ class PDBe:
 
             p.get_functional_annotation('1cbs')
 
-
         """
         query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("cofactor/{}".format(query))
-        else:
-            res = self.services.http_post("cofactor", data=query, frmt="json")
+        res = self.services.http_get(
+            "{}/cofactor/{}".format(self._entry_prefix, query)
+        )
         return self._return(res)
 
     def get_drugbank_annotation(self, query):
-        """This call provides DrugBank annotation of all ligands, i.e. 'bound'
+        """Provides DrugBank annotation of all ligands, i.e. 'bound' molecules.
 
         :param query: a 4-character PDB id code
 
@@ -500,33 +469,55 @@ class PDBe:
 
             p.get_drugbank_annotation('5hht')
 
-
         """
         query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("drugbank/{}".format(query))
-        else:
-            res = self.services.http_post("drugbank", data=query, frmt="json")
+        res = self.services.http_get(
+            "{}/drugbank/{}".format(self._entry_prefix, query)
+        )
         return self._return(res)
 
     def get_related_dataset(self, query):
-        """Provides DOI’s for related raw experimental datasets
+        """Provides DOIs for related raw experimental datasets.
 
         Includes diffraction image data, small-angle scattering data and
         electron micrographs.
-
 
         :param query: a 4-character PDB id code
 
         ::
 
-            p.get_cofactor('5o8b')
-
+            p.get_related_dataset('5o8b')
+            p.get_related_dataset('5o8b,5o8b')
 
         """
-        query = self._check_id(query)
-        if isinstance(query, str) and "," not in query:
-            res = self.services.http_get("related_experiment_data/{}".format(query))
-        else:
-            res = self.services.http_post("related_experiment_data", data=query, frmt="json")
-        return self._return(res)
+        return self._get_or_post("related_experiment_data", query)
+
+    def get_branched_entities(self, query):
+        """Provides data for branched carbohydrate entities within an entry.
+
+        Overall information about each unique branched carbohydrate is returned,
+        along with detailed information about each carbohydrate monomer within
+        the branched entity.
+
+        :param query: a 4-character PDB id code
+
+        ::
+
+            p.get_branched_entities('3d12')
+            p.get_branched_entities('3d12,7v7u')
+
+        """
+        return self._get_or_post("branched", query)
+
+    def get_carbohydrate_polymer(self, query):
+        """Provides data for carbohydrate polymers within an entry.
+
+        :param query: a 4-character PDB id code
+
+        ::
+
+            p.get_carbohydrate_polymer('3d12')
+            p.get_carbohydrate_polymer('3d12,7v7u')
+
+        """
+        return self._get_or_post("carbohydrate_polymer", query)

--- a/test/webservices/test_pdbe.py
+++ b/test/webservices/test_pdbe.py
@@ -1,71 +1,290 @@
+import pytest
 from bioservices import PDBe
 
 
-def test_pdbe():
-    p = PDBe(verbose=False)
-    res = p.get_summary("1cbs")
-    assert len(res) == 1
-    res = p.get_summary("1cbs,2kv8")
-    assert len(res) == 2
-    res = p.get_summary(["1cbs", "2kv8"])
-    assert len(res) == 2
+@pytest.fixture(scope="module")
+def pdbe():
+    return PDBe(verbose=False)
 
-    p.get_molecules("1cbs")
-    p.get_molecules("1cbs,2kv8")
 
-    p.get_related_publications("1cbs")
-    p.get_related_publications("1cbs")
+class TestGetSummary:
+    def test_single(self, pdbe):
+        res = pdbe.get_summary("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
 
-    p.get_experiment("1cbs")
-    p.get_experiment("1cbs,2kv8")
+    def test_comma_separated(self, pdbe):
+        res = pdbe.get_summary("1cbs,2kv8")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
 
-    p.get_nmr_resources("1cbs")
-    p.get_nmr_resources("1cbs,2kv8")
+    def test_list(self, pdbe):
+        res = pdbe.get_summary(["1cbs", "2kv8"])
+        assert isinstance(res, dict)
+        assert len(res) >= 2
 
-    p.get_ligand_monomers("1cbs")
-    p.get_ligand_monomers("1cbs,2kv8")
 
-    p.get_modified_residues("4v5j")
-    p.get_modified_residues("4v5j,1cbs")
+class TestGetMolecules:
+    def test_single(self, pdbe):
+        res = pdbe.get_molecules("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
 
-    p.get_mutated_residues("1bgj")
-    p.get_mutated_residues("1bgj,4v5j")
+    def test_multi(self, pdbe):
+        res = pdbe.get_molecules("1cbs,2kv8")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
 
-    p.get_release_status("1cbs")
-    p.get_release_status("1cbs,4v5j")
 
-    p.get_observed_ranges("1cbs")
-    p.get_observed_ranges("1cbs,4v5j")
+class TestGetEntities:
+    def test_single(self, pdbe):
+        res = pdbe.get_entities("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
 
-    p.get_observed_ranges_in_pdb_chain("1cbs", "A")
+    def test_multi(self, pdbe):
+        res = pdbe.get_entities("1cbs,2kv8")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
 
-    p.get_secondary_structure("1cbs")
-    p.get_secondary_structure("1cbs,4v5j")
 
-    p.get_residue_listing("1cbs")
+class TestGetPublications:
+    def test_single(self, pdbe):
+        res = pdbe.get_publications("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
 
-    p.get_residue_listing_in_pdb_chain("1cbs", "A")
+    def test_multi(self, pdbe):
+        res = pdbe.get_publications("1cbs,2kv8")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
 
-    p.get_binding_sites("1cbs")
-    p.get_binding_sites("1cbs,4v5j")
 
-    p.get_files("1cbs")
-    p.get_files("1cbs,4v5j")
+class TestGetRelatedPublications:
+    def test_single(self, pdbe):
+        res = pdbe.get_related_publications("1cbs")
+        assert isinstance(res, dict)
 
-    p.get_observed_residues_ratio("1cbs")
-    p.get_observed_residues_ratio("1cbs,4v5j")
+    def test_multi(self, pdbe):
+        res = pdbe.get_related_publications("1cbs,2kv8")
+        assert isinstance(res, dict)
 
-    p.get_assembly("1cbs")
-    p.get_assembly("1cbs,4v5j")
 
-    p.get_electron_density_statistics("1cbs")
-    p.get_electron_density_statistics("1cbs,4v5j")
+class TestGetExperiment:
+    def test_single(self, pdbe):
+        res = pdbe.get_experiment("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
 
-    p.get_drugbank_annotation("5hht")
-    p.get_drugbank_annotation("5hht,5hht")
+    def test_multi(self, pdbe):
+        res = pdbe.get_experiment("1cbs,2kv8")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
 
-    p.get_functional_annotation("1cbs,1cbs")
-    p.get_functional_annotation("1cbs")
 
-    p.get_related_dataset("5o8b")
-    p.get_related_dataset("5o8b,5o8b")
+class TestGetLigandMonomers:
+    def test_single(self, pdbe):
+        res = pdbe.get_ligand_monomers("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_ligand_monomers("1cbs,2kv8")
+        assert isinstance(res, dict)
+
+
+class TestGetModifiedResidues:
+    def test_single(self, pdbe):
+        res = pdbe.get_modified_residues("4v5j")
+        assert isinstance(res, dict)
+        assert "4v5j" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_modified_residues("4v5j,1cbs")
+        assert isinstance(res, dict)
+
+
+class TestGetMutatedResidues:
+    def test_single(self, pdbe):
+        res = pdbe.get_mutated_residues("1bgj")
+        assert isinstance(res, dict)
+        assert "1bgj" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_mutated_residues("1bgj,4v5j")
+        assert isinstance(res, dict)
+
+
+class TestGetReleaseStatus:
+    def test_single(self, pdbe):
+        res = pdbe.get_release_status("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_release_status("1cbs,4v5j")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
+
+
+class TestGetObservedRanges:
+    def test_single(self, pdbe):
+        res = pdbe.get_observed_ranges("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_observed_ranges("1cbs,4v5j")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
+
+
+class TestGetObservedRangesInPdbChain:
+    def test_single(self, pdbe):
+        res = pdbe.get_observed_ranges_in_pdb_chain("1cbs", "A")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+
+class TestGetSecondaryStructure:
+    def test_single(self, pdbe):
+        res = pdbe.get_secondary_structure("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_secondary_structure("1cbs,4v5j")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
+
+
+class TestGetResidueListing:
+    def test_single(self, pdbe):
+        res = pdbe.get_residue_listing("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+
+class TestGetResidueListingInPdbChain:
+    def test_single(self, pdbe):
+        res = pdbe.get_residue_listing_in_pdb_chain("1cbs", "A")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+
+class TestGetBindingSites:
+    def test_single(self, pdbe):
+        res = pdbe.get_binding_sites("1cbs", 1)
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+
+class TestGetFiles:
+    def test_single(self, pdbe):
+        res = pdbe.get_files("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_files("1cbs,4v5j")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
+
+
+class TestGetObservedResiduesRatio:
+    def test_single(self, pdbe):
+        res = pdbe.get_observed_residues_ratio("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_observed_residues_ratio("1cbs,4v5j")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
+
+
+class TestGetAssembly:
+    def test_single(self, pdbe):
+        res = pdbe.get_assembly("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_assembly("1cbs,4v5j")
+        assert isinstance(res, dict)
+        assert len(res) >= 2
+
+
+class TestGetElectronDensityStatistics:
+    def test_single(self, pdbe):
+        res = pdbe.get_electron_density_statistics("1cbs")
+        assert isinstance(res, dict)
+        assert "1cbs" in res
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_electron_density_statistics("1cbs,4v5j")
+        assert isinstance(res, dict)
+
+
+class TestGetFunctionalAnnotation:
+    def test_single(self, pdbe):
+        res = pdbe.get_functional_annotation("1cbs")
+        assert isinstance(res, dict)
+
+
+class TestGetDrugbankAnnotation:
+    def test_single(self, pdbe):
+        res = pdbe.get_drugbank_annotation("5hht")
+        assert isinstance(res, dict)
+
+
+class TestGetRelatedDataset:
+    def test_single(self, pdbe):
+        res = pdbe.get_related_dataset("5o8b")
+        assert isinstance(res, dict)
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_related_dataset("5o8b,5o8b")
+        assert isinstance(res, dict)
+
+
+class TestGetBranchedEntities:
+    def test_single(self, pdbe):
+        res = pdbe.get_branched_entities("3d12")
+        assert isinstance(res, dict)
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_branched_entities("3d12,7v7u")
+        assert isinstance(res, dict)
+
+
+class TestGetCarbohydratePolymer:
+    def test_single(self, pdbe):
+        res = pdbe.get_carbohydrate_polymer("3d12")
+        assert isinstance(res, dict)
+
+    def test_multi(self, pdbe):
+        res = pdbe.get_carbohydrate_polymer("3d12,7v7u")
+        assert isinstance(res, dict)
+
+
+class TestInvalidInput:
+    def test_id_too_long(self, pdbe):
+        with pytest.raises(AssertionError):
+            pdbe.get_summary("sdklfjslkdfj")
+
+    def test_id_too_short(self, pdbe):
+        with pytest.raises(AssertionError):
+            pdbe.get_summary("1c")
+
+    def test_wrong_type(self, pdbe):
+        with pytest.raises(TypeError):
+            pdbe.get_summary(12345)
+
+    def test_invalid_id_in_list(self, pdbe):
+        with pytest.raises(AssertionError):
+            pdbe.get_summary(["1cbs", "bad"])
+
+    def test_invalid_id_in_comma_separated(self, pdbe):
+        with pytest.raises(AssertionError):
+            pdbe.get_summary("1cbs,bad")


### PR DESCRIPTION
The PDBe suite is failing because the PDBe is now using [version 2 of their API](https://www.ebi.ac.uk/pdbe/api/v2/doc/). This sort of upgrade task seemed like a good one to throw tokens at, so I provided Claude Opus 4.6 with the updated [OpenAPI spec here](https://www.ebi.ac.uk/pdbe/api/v2/openapi.json) and asked for updated functionality and additional tests to cover all methods. For the avoidance of doubt, I've reviewed the code :-)

All 50 tests in `poetry run pytest test/webservices/test_pdbe.py` now pass and the doctest does as well via `poetry run pytest --doctest-modules src/bioservices/pdbe.py`.

A somewhat large change is the refactor to reduce redundancy within the methods by having a `_get_or_post` helper.

Note there are some breaking changes, due to breaking changes in the API:

- get_nmr_resources has been removed as it's been removed from the API
- get_binding_sites(query) now requires entity_id — The signature changed from get_binding_sites(query) to get_binding_sites(query, entity_id). The v2 API only provides binding sites at the entity level (/pdb/entry/binding_sites/{pdb_id}/{entity_id}), so existing calls like p.get_binding_sites("1cbs") will raise a TypeError for the missing argument, and p.get_binding_sites("1cbs,4v5j") (multi-ID) is no longer supported at all.
- get_functional_annotation lost multi-ID support — The old code accepted comma-separated IDs or lists (via POST to /cofactor). The v2 API only has a GET endpoint for cofactor, so calling p.get_functional_annotation("1cbs,1cbs") will now raise an AssertionError from the len(query) == 4 check.
- get_drugbank_annotation lost multi-ID support — Same situation as cofactor. The v2 API only offers a single-ID GET endpoint for drugbank.
- Response shapes may differ — The v2 API may return different JSON structures than v1. Any downstream code that accesses specific keys in response dictionaries could break silently.

Non-breaking changes (everything else):
- The base URL change and path prefix changes are internal implementation details invisible to callers.
- All other methods (get_summary, get_molecules, get_experiment, etc.) preserved their exact signatures and single-ID/multi-ID behavior.
- The new methods (get_entities, get_publications, get_branched_entities, get_carbohydrate_polymer) are purely additive.
- Bug fixes (e.g., get_mutated_residues and get_release_status were using http_get for multi-ID queries instead of http_post, so they were already broken) are improvements, not regressions.
- Added tests for invalid inputs